### PR TITLE
docs(DEX-3922): Enable MFE Config API usage on local env, add docs on using it

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -46,5 +46,5 @@ SESSION_COOKIE_DOMAIN='.local.overhang.io'
 
 PUBLIC_PATH='/wgulearning/'
 
-APP_ID=''
-MFE_CONFIG_API_URL=''
+APP_ID='wgulearning'
+MFE_CONFIG_API_URL='http://apps.local.overhang.io/api/mfe_config/v1'

--- a/docs/decisions/0008-use-mfe-config-api-feature-flags.rst
+++ b/docs/decisions/0008-use-mfe-config-api-feature-flags.rst
@@ -1,0 +1,42 @@
+8. Use MFE Config API for feature flags and custom site configuration
+---------------------------------------------------------------------
+
+Status
+------
+
+Proposed
+
+Context
+-------
+
+We would like to have a way for enabling and disabling features on the MFE depending on the site or product.
+
+We would also like to do customizations via configuration specific to sites or products without requiring a custom build for each.
+
+Decision
+--------
+
+Use the MFE Config API that is included with OpenEDX starting with olive version.
+
+The MFE Config API is a great option for this. It is enabled by default starting in olive, and you can add variables to it dynamically in the EDX admin, under "Site configuration" (as a JSON object under the MFE_CONFIG key), which also supports multi tenant installations.
+
+From the MFE code, we can get the values with the geConfig function, which is part of the @edx/frontend-platform package (https://openedx.github.io/frontend-platform/module-Config.html).
+
+On performance: The MFE Config API is cached by default.
+
+For the upgrade, we may need to manually enable the MFE Config API by setting the ENABLE_MFE_CONFIG_API setting in the Django config.
+
+On the MFE, we need to make sure to correctly set the APP_ID and MFE_CONFIG_API_URL env variables. See .env.development for an example.
+
+
+Consequences
+------------
+
+By using the MFE Config API we will be able to dynamically set configuration variables from the Django Admin under site config.
+
+References
+----------
+
+* https://github.com/openedx/edx-platform/blob/master/lms/djangoapps/mfe_config_api/docs/decisions/0001-mfe-config-api.rst
+* https://docs.openedx.org/en/latest/community/release_notes/olive.html#mfe-runtime-configuration
+* https://openedx.github.io/frontend-platform/module-Config.html


### PR DESCRIPTION
# Overview

Enable MFE Config API usage on local env, add docs on using it.

## Checklist

⚠️ **Please make sure to fill this checklist before asking for reviews.**

- [x] Code is correctly formatted and linted
- [x] Unit tests are updated and are passing
- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary):
      i.e. `feat(CUR-###): Feature title`
- [x] PR Title aligns to Semantic-Release [supported prefixes](https://www.conventionalcommits.org/en/v1.0.0/#examples) (NOTE: prefixes are case sensitive, keep lower-case):

```diff
 feat() - Feature (0.X.0)
 fix() - Patch (0.0.X)
 docs() - Patch (0.0.X), will only scope to README changes
 refactor() - Patch (0.0.X)
 revert() - Patch (0.0.X)
 style() - Patch (0.0.X)
```

- [x] Check for unused files
- [x] Check work before asking for reviewers
- [x] Fix any linting errors
- [x] SECURITY: No secrets where commited to the repo
- [x] COMPLIANCE: Commited code is not propietary and adheres to Open Source licensing
