### PR TITLE
refactor(dex-3920): Remove unnecessary redux slices

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,10 +1,14 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en-us">
   <head>
-      <title>Application Template | <%= process.env.SITE_NAME %></title>
-      <meta charset="utf-8">
-      <meta name="viewport" content="width=device-width, initial-scale=1.0">
-      <link rel="shortcut icon" href="<%=htmlWebpackPlugin.options.FAVICON_URL%>" type="image/x-icon" />
+    <title>Learning | <%= process.env.SITE_NAME %></title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link
+      rel="shortcut icon"
+      href="<%=htmlWebpackPlugin.options.FAVICON_URL%>"
+      type="image/x-icon"
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/src/app/store.js
+++ b/src/app/store.js
@@ -1,6 +1,6 @@
 import { configureStore } from '@reduxjs/toolkit';
 import {
-  courseHomeReducer, coursewareReducer, recommendationsReducer, toursReducer, modelsReducer,
+  coursewareReducer, modelsReducer,
 } from '@edx/frontend-app-learning';
 import { reducer as courseViewReducer } from '../features/course-view/data';
 
@@ -9,9 +9,6 @@ export default function initializeStore() {
     reducer: {
       models: modelsReducer,
       courseware: coursewareReducer,
-      courseHome: courseHomeReducer,
-      recommendations: recommendationsReducer,
-      tours: toursReducer,
       courseView: courseViewReducer,
     },
   });


### PR DESCRIPTION
# Overview

Removed courseHome, recommendations and tours reducers, which are not used by our code and are not a dependency for the imported Sequence components.

## Checklist

⚠️ **Please make sure to fill this checklist before asking for reviews.**

- [x] Code is correctly formatted and linted
- [x] Unit tests are updated and are passing
- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary):
      i.e. `feat(CUR-###): Feature title`
- [x] PR Title aligns to Semantic-Release [supported prefixes](https://www.conventionalcommits.org/en/v1.0.0/#examples) (NOTE: prefixes are case sensitive, keep lower-case):

```diff
 feat() - Feature (0.X.0)
 fix() - Patch (0.0.X)
 docs() - Patch (0.0.X), will only scope to README changes
 refactor() - Patch (0.0.X)
 revert() - Patch (0.0.X)
 style() - Patch (0.0.X)
```

- [x] Check for unused files
- [x] Check work before asking for reviewers
- [x] Fix any linting errors
- [x] SECURITY: No secrets where commited to the repo
- [x] COMPLIANCE: Commited code is not propietary and adheres to Open Source licensing
