### PR TITLE
feat(DEX-4053): Connect header title with course number and title

### DIFF
--- a/src/features/header/Header.jsx
+++ b/src/features/header/Header.jsx
@@ -1,15 +1,21 @@
 import React from 'react';
 import Responsive from 'react-responsive';
 import { getConfig } from '@edx/frontend-platform';
+import { useSelector } from 'react-redux';
 
 // Local Components
 import DesktopHeader from './DesktopHeader';
 import MobileHeader from './MobileHeader';
+import { currentCourseHomeMetaSelector } from './data/selectors';
 
 const Header = () => {
+  const course = useSelector(currentCourseHomeMetaSelector);
+
   const props = {
     logo: getConfig().LOGO_WHITE_URL,
     logoAltText: getConfig().SITE_NAME,
+    courseTitle: course?.title,
+    courseNumber: course?.number,
   };
 
   return (

--- a/src/features/header/Header.test.jsx
+++ b/src/features/header/Header.test.jsx
@@ -1,11 +1,34 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { Factory } from 'rosie';
 import { Provider } from 'react-redux';
+import { breakpoints } from '@edx/paragon';
+import { Context as ResponsiveContext } from 'react-responsive';
 
 // Local Components
 import DesktopHeader from './DesktopHeader';
 import MobileHeader from './MobileHeader';
 import initializeStore from '../../app/store';
+import Header from './Header';
+import { initializeTestStore, render, screen } from '../../setupTest';
+
+describe('Header', () => {
+  let courseHomeMetadata;
+
+  beforeAll(async () => {
+    courseHomeMetadata = Factory.build('courseHomeMetadata');
+    await initializeTestStore({ courseHomeMetadata });
+  });
+
+  it('Renders with course title from store', () => {
+    render(
+      <ResponsiveContext.Provider value={{ width: breakpoints.extraLarge.minWidth }}>
+        <Header />
+      </ResponsiveContext.Provider>,
+    );
+    expect(screen.getByText(courseHomeMetadata.number, { exact: false }));
+    expect(screen.getByText(courseHomeMetadata.title, { exact: false }));
+  });
+});
 
 describe('DesktopHeader', () => {
   it('displays course data', () => {

--- a/src/features/header/data/selectors.js
+++ b/src/features/header/data/selectors.js
@@ -1,0 +1,8 @@
+import { createSelector } from 'reselect';
+
+// eslint-disable-next-line import/prefer-default-export
+export const currentCourseHomeMetaSelector = createSelector(
+  (state) => state.models.courseHomeMeta || {},
+  (state) => state.courseware.courseId,
+  (coursesById, courseId) => (coursesById[courseId] ? coursesById[courseId] : null),
+);

--- a/src/setupTest.js
+++ b/src/setupTest.js
@@ -119,12 +119,6 @@ export function logUnhandledRequests(axiosMock) {
 let globalStore;
 
 export async function initializeTestStore(options = {}, overrideStore = true) {
-  // Always fill courseHomeMetadata as an empty object in options
-  // As we are not using that slice, but is needed for some mocking
-  // functions imported from frontend-app-learning
-  // eslint-disable-next-line no-param-reassign
-  options.courseHomeMetadata = {};
-
   const store = configureStore({
     reducer: {
       models: modelsReducer,
@@ -140,7 +134,7 @@ export async function initializeTestStore(options = {}, overrideStore = true) {
   axiosMock.reset();
 
   const {
-    courseBlocks, sequenceBlocks, courseMetadata, sequenceMetadata,
+    courseBlocks, sequenceBlocks, courseMetadata, sequenceMetadata, courseHomeMetadata,
   } = buildSimpleCourseAndSequenceMetadata(options);
 
   let courseMetadataUrl = `${getConfig().LMS_BASE_URL}/api/courseware/course/${courseMetadata.id}`;
@@ -152,7 +146,7 @@ export async function initializeTestStore(options = {}, overrideStore = true) {
   courseHomeMetadataUrl = appendBrowserTimezoneToUrl(courseHomeMetadataUrl);
 
   axiosMock.onGet(courseMetadataUrl).reply(200, courseMetadata);
-  axiosMock.onGet(courseHomeMetadataUrl).reply(200, { }); // Empty response as we are not using this
+  axiosMock.onGet(courseHomeMetadataUrl).reply(200, courseHomeMetadata);
   axiosMock.onGet(learningSequencesUrlRegExp).reply(200, buildOutlineFromBlocks(courseBlocks));
   axiosMock.onGet(discussionConfigUrl).reply(200, { provider: 'legacy' });
   sequenceMetadata.forEach(metadata => {


### PR DESCRIPTION
# Overview

Connected app header so it displays the course number and title given by the redux store.

## Checklist

⚠️ **Please make sure to fill this checklist before asking for reviews.**

- [x] Code is correctly formatted and linted
- [x] Unit tests are updated and are passing
- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary):
      i.e. `feat(CUR-###): Feature title`
- [x] PR Title aligns to Semantic-Release [supported prefixes](https://www.conventionalcommits.org/en/v1.0.0/#examples) (NOTE: prefixes are case sensitive, keep lower-case):

```diff
 feat() - Feature (0.X.0)
 fix() - Patch (0.0.X)
 docs() - Patch (0.0.X), will only scope to README changes
 refactor() - Patch (0.0.X)
 revert() - Patch (0.0.X)
 style() - Patch (0.0.X)
```

- [x] Check for unused files
- [x] Check work before asking for reviewers
- [x] Fix any linting errors
- [x] SECURITY: No secrets where commited to the repo
- [x] COMPLIANCE: Commited code is not propietary and adheres to Open Source licensing
