### PR TITLE
fix(DEX-4054): Workaround for Firefox bug

### DIFF
--- a/src/features/course-player/CoursePlayer.jsx
+++ b/src/features/course-player/CoursePlayer.jsx
@@ -9,7 +9,7 @@ import {
   checkBlockCompletion,
   saveSequencePosition as saveSequencePositionAction,
 } from '@edx/frontend-app-learning';
-import { useEffect } from 'react';
+import { useEffect, useLayoutEffect, useState } from 'react';
 import classNames from 'classnames';
 import SequenceContainer from './sequence-container/SequenceContainer';
 import {
@@ -32,6 +32,43 @@ import {
 ensureConfig([
   'DISABLE_APP_HEADER',
 ], 'CoursePlayer component');
+
+/**
+ * Workaround for an error in Firefox, it exists on the original frontend-app-learning, but needs to be
+ * re-applied here due to the conditional rendering of SequenceContainer.
+ *
+ * Description from https://github.com/openedx/frontend-app-learning/blob/open-release/olive.4/src/courseware/course/sequence/Unit.jsx#L38:
+ *
+ * We discovered an error in Firefox where - upon iframe load - React would cease to call any
+ * useEffect hooks until the user interacts with the page again.  This is particularly confusing
+ * when navigating between sequences, as the UI partially updates leaving the user in a nebulous
+ * state.
+ *
+ * We were able to solve this error by using a layout effect to update some component state, which
+ * executes synchronously on render.  Somehow this forces React to continue it's lifecycle
+ * immediately, rather than waiting for user interaction.  This layout effect could be anywhere in
+ * the parent tree, as far as we can tell - we chose to add a conspicuously 'load bearing' (that's
+ * a joke) one here so it wouldn't be accidentally removed elsewhere.
+ *
+ * If we remove this hook when one of these happens:
+ * 1. React figures out that there's an issue here and fixes a bug.
+ * 2. We cease to use an iframe for unit rendering.
+ * 3. Firefox figures out that there's an issue in their iframe loading and fixes a bug.
+ * 4. We stop supporting Firefox.
+ * 5. An enterprising engineer decides to create a repo that reproduces the problem, submits it to
+ *    Firefox/React for review, and they kindly help us figure out what in the world is happening
+ *    so  we can fix it.
+ *
+ * This hook depends on the unit id just to make sure it re-evaluates whenever the ID changes.  If
+ * we change whether or not the Unit component is re-mounted when the unit ID changes, this may
+ * become important, as this hook will otherwise only evaluate the useLayoutEffect once.
+ */
+function useLoadBearingHook(id) {
+  const setValue = useState(0)[1];
+  useLayoutEffect(() => {
+    setValue(currentValue => currentValue + 1);
+  }, [id, setValue]);
+}
 
 const CoursePlayer = (props) => {
   const {
@@ -62,6 +99,9 @@ const CoursePlayer = (props) => {
 
   const saveUnitPosition = sequence?.saveUnitPosition;
   const unitIds = sequence?.unitIds;
+
+  // Do not remove this hook. See function description.
+  useLoadBearingHook(routeUnitId);
 
   // checkSaveSequencePosition
   useEffect(() => {


### PR DESCRIPTION
# Overview

Added workaround to fix an issue that only happens in Firefox when navigating between sections, which showed a blank screen until the user clicked anywhere on the screen.

## Checklist

⚠️ **Please make sure to fill this checklist before asking for reviews.**

- [x] Code is correctly formatted and linted
- [x] Unit tests are updated and are passing
- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary):
      i.e. `feat(CUR-###): Feature title`
- [x] PR Title aligns to Semantic-Release [supported prefixes](https://www.conventionalcommits.org/en/v1.0.0/#examples) (NOTE: prefixes are case sensitive, keep lower-case):

```diff
 feat() - Feature (0.X.0)
 fix() - Patch (0.0.X)
 docs() - Patch (0.0.X), will only scope to README changes
 refactor() - Patch (0.0.X)
 revert() - Patch (0.0.X)
 style() - Patch (0.0.X)
```

- [x] Check for unused files
- [x] Check work before asking for reviewers
- [x] Fix any linting errors
- [x] SECURITY: No secrets where commited to the repo
- [x] COMPLIANCE: Commited code is not propietary and adheres to Open Source licensing
