### PR TITLE
refactor(DEX-4085): sidebar header is now absolute

### DIFF
--- a/src/features/course-view/CourseView.scss
+++ b/src/features/course-view/CourseView.scss
@@ -26,12 +26,14 @@ $minimized-sidebar-width: 36px;
   height: 100%;
   display: flex;
   flex-direction: column;
+  position: relative;
 }
 
 .sidebar-content {
   overflow-y: scroll;
   height: 100%;
   padding-right: 32px;
+  margin-top: 24px;
 
   @media (max-width: map-get($grid-breakpoints, "md")) {
     padding-right: 0px;
@@ -41,6 +43,7 @@ $minimized-sidebar-width: 36px;
 .white-background {
   background: white;
   height: 100%;
+  padding-top: 38px;
 }
 
 .sidebar-header {
@@ -54,6 +57,8 @@ $minimized-sidebar-width: 36px;
   width: 100%;
   justify-content: center;
   align-items: center;
+  position: absolute;
+  z-index: 10;
 
   @media (max-width: map-get($grid-breakpoints, "md")) {
     border-top-right-radius: 0px;


### PR DESCRIPTION
# Overview

Sidebar header is now absolute and now the current unit mark is visible when scrolling.

## Checklist

⚠️ **Please make sure to fill this checklist before asking for reviews.**

- [x] Code is correctly formatted and linted
- [x] Unit tests are updated and are passing
- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary):
      i.e. `feat(CUR-###): Feature title`
- [x] PR Title aligns to Semantic-Release [supported prefixes](https://www.conventionalcommits.org/en/v1.0.0/#examples) (NOTE: prefixes are case sensitive, keep lower-case):

```diff
 feat() - Feature (0.X.0)
 fix() - Patch (0.0.X)
 docs() - Patch (0.0.X), will only scope to README changes
 refactor() - Patch (0.0.X)
 revert() - Patch (0.0.X)
 style() - Patch (0.0.X)
```

- [x] Check for unused files
- [x] Check work before asking for reviewers
- [x] Fix any linting errors
- [x] SECURITY: No secrets where commited to the repo
- [x] COMPLIANCE: Commited code is not propietary and adheres to Open Source licensing
