### PR TITLE
fix(DEX-4099): Fix sidebar content and title being lost after navigation

### DIFF
--- a/src/components/Section/Section.jsx
+++ b/src/components/Section/Section.jsx
@@ -14,7 +14,7 @@ const statusIcons = {
 };
 
 const Section = ({
-  currentUnitId, collapsibleMenuState = {}, id, title, status = 'pending', sequences = [], onOpenCollapse, isActiveSection,
+  courseId, currentUnitId, collapsibleMenuState = {}, id, title, status = 'pending', sequences = [], onOpenCollapse, isActiveSection,
 }) => (
   <div className="sidebar-item-container">
     <button data-testid={`section-button-${id}`} type="button" className={classNames('sidebar-item-header', { active: isActiveSection }, status, 'section')} onClick={() => onOpenCollapse(id)}>{collapsibleMenuState[id] ? <CarrotIconDown className="carrot-down" /> : <CarrotIconRight className="carrot" />} <span className="sidebar-item-title">{title}</span> {statusIcons[status]}</button>
@@ -22,6 +22,7 @@ const Section = ({
       {sequences.map(sequence => (
         <Sequence
           key={sequence.id}
+          courseId={courseId}
           collapsibleMenuState={collapsibleMenuState}
           status={sequence.status}
           currentUnitId={currentUnitId}
@@ -48,6 +49,7 @@ Section.propTypes = {
   })).isRequired,
   onOpenCollapse: PropTypes.func.isRequired,
   collapsibleMenuState: PropTypes.objectOf(PropTypes.bool).isRequired,
+  courseId: PropTypes.string.isRequired,
   currentUnitId: PropTypes.string.isRequired,
   isActiveSection: PropTypes.bool.isRequired,
 };

--- a/src/components/Sequence/Sequence.jsx
+++ b/src/components/Sequence/Sequence.jsx
@@ -14,7 +14,7 @@ const statusIcons = {
 };
 
 const Sequence = ({
-  id, title, status = 'pending', units = [], onOpenCollapse, collapsibleMenuState = {}, currentUnitId, isActiveSequence,
+  id, title, status = 'pending', units = [], onOpenCollapse, collapsibleMenuState = {}, courseId, currentUnitId, isActiveSequence,
 }) => (
   <div className="sidebar-item-container">
     <button data-testid={`sequence-button-${id}`} type="button" className={classNames('sidebar-item-header', { active: isActiveSequence }, status, 'sequence')} onClick={() => onOpenCollapse(id, 'sequence')}>{units.length > 0 && (collapsibleMenuState[id] ? <CarrotIconDown className="carrot-down" /> : <CarrotIconRight className="carrot" />)} <span className="sidebar-item-title">{title}</span> {statusIcons[status]}</button>
@@ -22,6 +22,7 @@ const Sequence = ({
       {units.map(unit => (
         <Unit
           key={unit.id}
+          courseId={courseId}
           complete={unit.complete}
           id={unit.id}
           sequenceId={id}
@@ -41,6 +42,7 @@ Sequence.propTypes = {
   units: PropTypes.string.isRequired,
   onOpenCollapse: PropTypes.func.isRequired,
   collapsibleMenuState: PropTypes.objectOf(PropTypes.bool).isRequired,
+  courseId: PropTypes.string.isRequired,
   currentUnitId: PropTypes.string.isRequired,
   isActiveSequence: PropTypes.bool.isRequired,
 };

--- a/src/components/Unit/Unit.jsx
+++ b/src/components/Unit/Unit.jsx
@@ -12,7 +12,7 @@ const statusIcons = {
 };
 
 const Unit = ({
-  id, sequenceId, title, complete, isCurrentUnit, isActiveUnit,
+  id, courseId, sequenceId, title, complete, isCurrentUnit, isActiveUnit,
 }) => {
   const getStatus = () => {
     if (complete) {
@@ -26,7 +26,7 @@ const Unit = ({
   };
 
   return (
-    <button type="button" className="sidebar-item-container" onClick={() => history.push(`/course/course-v1:edX+DemoX+Demo_Course/${sequenceId}/${id}`)}>
+    <button type="button" className="sidebar-item-container" onClick={() => history.push(`/course/${courseId}/${sequenceId}/${id}`)}>
       <div className={classNames('sidebar-item-header', {
         current: isCurrentUnit,
         active: isActiveUnit,
@@ -39,6 +39,7 @@ const Unit = ({
 
 Unit.propTypes = {
   id: PropTypes.string.isRequired,
+  courseId: PropTypes.string.isRequired,
   sequenceId: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
   complete: PropTypes.bool.isRequired,

--- a/src/features/course-view/data/selectors.js
+++ b/src/features/course-view/data/selectors.js
@@ -76,3 +76,8 @@ export const sectionSequenceIdsSelector = createSelector(
   state => state.models.sequences,
   (sections = {}, sequences = {}) => ([...Object.keys(sections), ...Object.keys(sequences)]),
 );
+
+export const currentCourseIdSelector = createSelector(
+  (state) => state.courseware,
+  (courseware) => courseware?.courseId,
+);

--- a/src/features/header/Header.jsx
+++ b/src/features/header/Header.jsx
@@ -12,8 +12,8 @@ const Header = () => {
 
   const logo = getConfig().LOGO_WHITE_URL;
   const logoAltText = getConfig().SITE_NAME;
-  const courseTitle = course?.title;
-  const courseNumber = course?.number;
+  const courseTitle = course?.title || '';
+  const courseNumber = course?.number || '';
 
   const dispatch = useDispatch();
 

--- a/src/features/sidebar/Sidebar.jsx
+++ b/src/features/sidebar/Sidebar.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
-import { sectionSequenceUnitsSelector } from '../course-view/data/selectors';
+import { sectionSequenceUnitsSelector, currentCourseIdSelector } from '../course-view/data/selectors';
 import Section from '../../components/Section/Section';
 import CarrotIconLeft from '../../assets/CarrotIconLeft';
 import CarrotIconDown from '../../assets/CarrotIcon';
@@ -10,6 +10,7 @@ import CarrotIconTop from '../../assets/CarrotIconTop';
 
 const Sidebar = ({ currentUnitId, sequenceId }) => {
   const dispatch = useDispatch();
+  const courseId = useSelector(currentCourseIdSelector);
   const sectionSequenceUnits = useSelector(sectionSequenceUnitsSelector);
   const collapsibleMenuState = useSelector(collapsibleMenuStateSelector);
 
@@ -38,6 +39,7 @@ const Sidebar = ({ currentUnitId, sequenceId }) => {
             <Section
               key={section.id}
               collapsibleMenuState={collapsibleMenuState}
+              courseId={courseId}
               currentUnitId={currentUnitId}
               id={section.id}
               title={section.title}


### PR DESCRIPTION
# Overview

Fix sidebar content and title being lost after navigation.
This was caused due to a hardcoded courseId on the url redirection when clicking a unit in the sidebar.
Also added logic to avoid showing "undefined undefined" in the title while the course data is loading.

## Checklist

⚠️ **Please make sure to fill this checklist before asking for reviews.**

- [x] Code is correctly formatted and linted
- [x] Unit tests are updated and are passing
- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary):
      i.e. `feat(CUR-###): Feature title`
- [x] PR Title aligns to Semantic-Release [supported prefixes](https://www.conventionalcommits.org/en/v1.0.0/#examples) (NOTE: prefixes are case sensitive, keep lower-case):

```diff
 feat() - Feature (0.X.0)
 fix() - Patch (0.0.X)
 docs() - Patch (0.0.X), will only scope to README changes
 refactor() - Patch (0.0.X)
 revert() - Patch (0.0.X)
 style() - Patch (0.0.X)
```

- [x] Check for unused files
- [x] Check work before asking for reviewers
- [x] Fix any linting errors
- [x] SECURITY: No secrets where commited to the repo
- [x] COMPLIANCE: Commited code is not propietary and adheres to Open Source licensing
