### PR TITLE
feat(DEX-4148): Footer updates

### DIFF
--- a/src/features/course-player/CoursePlayer.scss
+++ b/src/features/course-player/CoursePlayer.scss
@@ -15,8 +15,7 @@
 
   @media (max-width: map-get($grid-breakpoints, "xl")) {
     padding: 0rem;
-    // Makes sure footer is always at least at the bottom of the screen:
-    min-height: calc(100vh - $mobile-footer-height - $mobile-header-height);
+    
     .course-player-sequence-container {
       padding: 0rem;
       border-radius: 0rem;
@@ -26,6 +25,11 @@
     &.disable-app-header {
       min-height: calc(100vh - $mobile-footer-height);
     }
+  }
+
+  @media (max-width: map-get($grid-breakpoints, "lg")) {
+    // Makes sure footer is always at least at the bottom of the screen:
+    min-height: calc(100vh - $mobile-footer-height - $mobile-header-height);
   }
 
   

--- a/src/features/course-view/CourseView.scss
+++ b/src/features/course-view/CourseView.scss
@@ -1,6 +1,3 @@
-$extended-sidebar-width: 457px;
-$minimized-sidebar-width: 36px;
-
 .cv-course-sidebar {
   position: fixed;
   top: 0;
@@ -8,11 +5,10 @@ $minimized-sidebar-width: 36px;
   height: 100vh;
   width: $minimized-sidebar-width;
   padding-top: $desktop-header-height;
-  padding-bottom: $desktop-footer-height;
+  padding-bottom: 0px;
 
   @media (max-width: map-get($grid-breakpoints, "xl")) {
     padding-top: $mobile-header-height;
-    padding-bottom: 0px;
     width: 100%;
     z-index: 1;
   }

--- a/src/features/course-view/CourseView.scss
+++ b/src/features/course-view/CourseView.scss
@@ -12,6 +12,7 @@
     padding-top: $mobile-header-height;
     width: 100%;
     z-index: 1;
+    left: 0;
   }
 
   &.disable-app-header {

--- a/src/features/footer/Footer.jsx
+++ b/src/features/footer/Footer.jsx
@@ -59,14 +59,15 @@ const Footer = ({ className }) => {
           alt={logoAltText}
         />
         <a
-          className="d-block branded-link"
+          className="d-block branded-link aria-tooltip-link"
           href={adaUrl}
           target="_blank"
           rel="noreferrer"
-          aria-label="Opens in new tab"
+          aria-label="ADA Accommodation (opens in a new tab)"
           onClick={externalLinkClickHandler}
         >
           ADA Accommodation
+          <span className="aria-tooltip">Opens in a new tab</span>
         </a>
       </div>
       <div className="footer-section-container footer-bottom-container">
@@ -81,7 +82,7 @@ const Footer = ({ className }) => {
           {links.map((link, index) => (
             <>
               <a
-                className="info-link"
+                className="info-link aria-tooltip-link"
                 href={link.url}
                 target="_blank"
                 rel="noreferrer"
@@ -89,6 +90,7 @@ const Footer = ({ className }) => {
                 onClick={externalLinkClickHandler}
               >
                 {link.label}
+                <span className="aria-tooltip">Opens in a new tab</span>
               </a>
               {links.length !== (index + 1) && (
               <span className="link-divider">

--- a/src/features/footer/Footer.jsx
+++ b/src/features/footer/Footer.jsx
@@ -3,6 +3,8 @@ import { ensureConfig } from '@edx/frontend-platform/config';
 import { getConfig } from '@edx/frontend-platform';
 import { sendTrackEvent } from '@edx/frontend-platform/analytics';
 import React, { useContext } from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import { EVENT_NAMES, COPY_SYMBOL } from './constants';
 
 ensureConfig([
@@ -15,7 +17,7 @@ ensureConfig([
   'SITE_NAME',
 ], 'Footer component');
 
-const Footer = () => {
+const Footer = ({ className }) => {
   const { config } = useContext(AppContext);
 
   const adaUrl = getConfig().ADA_URL;
@@ -49,7 +51,7 @@ const Footer = () => {
   return (
     <footer
       role="contentinfo"
-      className="footer"
+      className={classNames('footer', className)}
     >
       <div className="footer-section-container">
         <img
@@ -99,6 +101,14 @@ const Footer = () => {
       </div>
     </footer>
   );
+};
+
+Footer.propTypes = {
+  className: PropTypes.string,
+};
+
+Footer.defaultProps = {
+  className: '',
 };
 
 export default Footer;

--- a/src/features/footer/Footer.jsx
+++ b/src/features/footer/Footer.jsx
@@ -63,11 +63,11 @@ const Footer = ({ className }) => {
           href={adaUrl}
           target="_blank"
           rel="noreferrer"
-          aria-label="ADA Accommodation (opens in a new tab)"
+          aria-label="ADA Accommodation (opens in new tab)"
           onClick={externalLinkClickHandler}
         >
           ADA Accommodation
-          <span className="aria-tooltip">Opens in a new tab</span>
+          <span className="aria-tooltip">Opens in new tab</span>
         </a>
       </div>
       <div className="footer-section-container footer-bottom-container">
@@ -86,11 +86,11 @@ const Footer = ({ className }) => {
                 href={link.url}
                 target="_blank"
                 rel="noreferrer"
-                aria-label={`${link.label} (opens in a new tab)`}
+                aria-label={`${link.label} (opens in new tab)`}
                 onClick={externalLinkClickHandler}
               >
                 {link.label}
-                <span className="aria-tooltip">Opens in a new tab</span>
+                <span className="aria-tooltip">Opens in new tab</span>
               </a>
               {links.length !== (index + 1) && (
               <span className="link-divider">

--- a/src/features/footer/Footer.jsx
+++ b/src/features/footer/Footer.jsx
@@ -68,7 +68,7 @@ const Footer = () => {
         </a>
       </div>
       <div className="footer-section-container footer-bottom-container">
-        <div className="">
+        <div className="footer-copy">
           <span>
             {COPY_SYMBOL}
             {' '}

--- a/src/features/footer/Footer.scss
+++ b/src/features/footer/Footer.scss
@@ -3,7 +3,7 @@
   font-size: 14px;
   height: $desktop-footer-height;
 
-  @media (max-width: map-get($grid-breakpoints, "xl")) {
+  @media (max-width: map-get($grid-breakpoints, "lg")) {
     height: $mobile-footer-height;
   }
 
@@ -23,12 +23,20 @@
       column-gap: 12px;
       flex-wrap: wrap;
     }
+
+    @media (min-width: map-get($grid-breakpoints, "xl")) and (max-width: map-get($grid-breakpoints, "xxl")) {
+      padding: 8px 8px;
+
+      .footer-copy {
+        font-size: 0.8em;;
+      }
+    }
   }
 
   .footer-bottom-container {
     padding-top: 0px;
 
-    @media (max-width: map-get($grid-breakpoints, "xl")) {
+    @media (max-width: map-get($grid-breakpoints, "lg")) {
       flex-direction: column;
     }
   }

--- a/src/features/footer/Footer.scss
+++ b/src/features/footer/Footer.scss
@@ -63,12 +63,11 @@
       background-color: $primary-500;;
       color: $gray-100;
       text-align: center;
-      padding: 2px 2px;
+      padding: 2px;
       border-radius: 8px;
 
       font-size: 12px;
 
-      /* Position the tooltip text - see examples below! */
       position: absolute;
       bottom: 22px;
       right: 0;

--- a/src/features/footer/Footer.scss
+++ b/src/features/footer/Footer.scss
@@ -28,7 +28,7 @@
       padding: 8px 8px;
 
       .footer-copy {
-        font-size: 0.8em;;
+        font-size: 0.8em;
       }
     }
   }
@@ -53,5 +53,32 @@
 
   .link-divider {
     color: $info-500;
+  }
+
+  .aria-tooltip-link {
+    position: relative;
+    .aria-tooltip {
+      visibility: hidden;
+      width: 130px;
+      background-color: $primary-500;;
+      color: $gray-100;
+      text-align: center;
+      padding: 2px 2px;
+      border-radius: 8px;
+
+      font-size: 12px;
+
+      /* Position the tooltip text - see examples below! */
+      position: absolute;
+      bottom: 22px;
+      right: 0;
+      z-index: 1;
+    }
+
+    &:hover {
+      .aria-tooltip {
+        visibility: visible;
+      }
+    }
   }
 }

--- a/src/features/layout/Layout.jsx
+++ b/src/features/layout/Layout.jsx
@@ -1,8 +1,12 @@
 import classNames from 'classnames';
 import { ensureConfig, getConfig } from '@edx/frontend-platform/config';
 import PropTypes from 'prop-types';
+import { useSelector } from 'react-redux';
 import Header from '../header/Header';
 import Footer from '../footer/Footer';
+import {
+  isDesktopSidebarExtendedSelector,
+} from '../course-view/data/selectors';
 
 ensureConfig([
   'DISABLE_APP_HEADER',
@@ -10,6 +14,7 @@ ensureConfig([
 
 const Layout = ({ children }) => {
   const disableAppHeader = getConfig().DISABLE_APP_HEADER === true;
+  const isSidebarExtended = useSelector(isDesktopSidebarExtendedSelector);
 
   return (
     <>
@@ -17,7 +22,7 @@ const Layout = ({ children }) => {
       <div className={classNames('layout-body', { 'disable-app-header': disableAppHeader })}>
         {children}
       </div>
-      <Footer />
+      <Footer className={classNames({ 'footer-sidebar-extended': isSidebarExtended })} />
     </>
   );
 };

--- a/src/features/layout/Layout.scss
+++ b/src/features/layout/Layout.scss
@@ -5,22 +5,19 @@
 }
 
 #root > footer {
-  position: fixed;
-  bottom: 0;
   width: 100%;
+  padding-left: $extended-sidebar-width - 42px; // 42px is the internal padding on the sidebar transparent part
   @media (max-width: map-get($grid-breakpoints, "xl")) {
-    position: relative;
-    bottom: unset;
+    padding-left: 0px; 
   }
 }
 
 #root > .layout-body {
   padding-top: $desktop-header-height;
-  padding-bottom: $desktop-footer-height;
+  padding-bottom: 0px;
 
   @media (max-width: map-get($grid-breakpoints, "xl")) {
     padding-top: $mobile-header-height;
-    padding-bottom: 0px;
   }
 
   &.disable-app-header {

--- a/src/features/layout/Layout.scss
+++ b/src/features/layout/Layout.scss
@@ -6,9 +6,13 @@
 
 #root > footer {
   width: 100%;
-  padding-left: $extended-sidebar-width - 42px; // 42px is the internal padding on the sidebar transparent part
+  padding-left: $minimized-sidebar-width + 8px;
   @media (max-width: map-get($grid-breakpoints, "xl")) {
     padding-left: 0px; 
+  }
+
+  &.footer-sidebar-extended {
+    padding-left: $extended-sidebar-width - 42px; // 42px is the internal padding on the sidebar transparent part
   }
 }
 

--- a/src/features/layout/Layout.scss
+++ b/src/features/layout/Layout.scss
@@ -8,11 +8,14 @@
   width: 100%;
   padding-left: $minimized-sidebar-width + 8px;
   @media (max-width: map-get($grid-breakpoints, "xl")) {
-    padding-left: 0px; 
+    padding-left: 0px;
   }
 
   &.footer-sidebar-extended {
     padding-left: $extended-sidebar-width - 42px; // 42px is the internal padding on the sidebar transparent part
+    @media (max-width: map-get($grid-breakpoints, "xl")) {
+      padding-left: 0px;
+    }
   }
 }
 

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -6,3 +6,6 @@ $desktop-footer-height: 69.77px;
 
 $mobile-header-height: 63.11px;
 $mobile-footer-height: 143.09px;
+
+$extended-sidebar-width: 457px;
+$minimized-sidebar-width: 36px;


### PR DESCRIPTION
# Overview

On Desktop, changed the footer so it is not fixed at the bottom of the screen and only occupies the space below the course content and not the sidebar.

Also added/corrected aria-labels on footer links and added a tooltip on hover to indicate that those will open new tabs.

## Checklist

⚠️ **Please make sure to fill this checklist before asking for reviews.**

- [x] Code is correctly formatted and linted
- [x] Unit tests are updated and are passing
- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary):
      i.e. `feat(CUR-###): Feature title`
- [x] PR Title aligns to Semantic-Release [supported prefixes](https://www.conventionalcommits.org/en/v1.0.0/#examples) (NOTE: prefixes are case sensitive, keep lower-case):

```diff
 feat() - Feature (0.X.0)
 fix() - Patch (0.0.X)
 docs() - Patch (0.0.X), will only scope to README changes
 refactor() - Patch (0.0.X)
 revert() - Patch (0.0.X)
 style() - Patch (0.0.X)
```

- [x] Check for unused files
- [x] Check work before asking for reviewers
- [x] Fix any linting errors
- [x] SECURITY: No secrets where commited to the repo
- [x] COMPLIANCE: Commited code is not propietary and adheres to Open Source licensing
