### PR TITLE
fix(DEX-4131): Close sidebar on unit selection in mobile

### DIFF
--- a/src/components/Unit/Unit.jsx
+++ b/src/components/Unit/Unit.jsx
@@ -1,8 +1,10 @@
 import PropTypes from 'prop-types';
 import { history } from '@edx/frontend-platform';
+import { useDispatch } from 'react-redux';
 import classNames from 'classnames';
 import CompletedIcon from '../../assets/CompletedIcon';
 import PendingIcon from '../../assets/PendingIcon';
+import { closeMobileSidebar } from '../../features/course-view/data/slice';
 
 const statusIcons = {
   pending: <PendingIcon />,
@@ -14,8 +16,17 @@ const Unit = ({
 }) => {
   const status = complete ? 'completed' : 'pending';
 
+  const dispatch = useDispatch();
+
+  const handleClick = () => {
+    // Navigate
+    history.push(`/course/${courseId}/${sequenceId}/${id}`);
+    // Close sidebar
+    dispatch(closeMobileSidebar());
+  };
+
   return (
-    <button type="button" className="sidebar-item-container" onClick={() => history.push(`/course/${courseId}/${sequenceId}/${id}`)}>
+    <button type="button" className="sidebar-item-container" onClick={handleClick}>
       <div className={classNames('sidebar-item-header', {
         current: isCurrentUnit,
         active: isActiveUnit,

--- a/src/components/Unit/Unit.jsx
+++ b/src/components/Unit/Unit.jsx
@@ -26,7 +26,7 @@ const Unit = ({
   };
 
   return (
-    <button type="button" className="sidebar-item-container" onClick={handleClick}>
+    <button type="button" className="sidebar-item-container" data-testid={`unit-button-${id}`} onClick={handleClick}>
       <div className={classNames('sidebar-item-header', {
         current: isCurrentUnit,
         active: isActiveUnit,

--- a/src/constants/mockData.js
+++ b/src/constants/mockData.js
@@ -885,7 +885,7 @@ export const sidebarMockStore = {
     sequenceMightBeUnit: false,
   },
   courseView: {
-    isMobileSidebarOpen: false,
+    isMobileSidebarOpen: true,
     isDesktopSidebarExtended: true,
   },
   sidebar: {

--- a/src/features/sidebar/Sidebar.test.jsx
+++ b/src/features/sidebar/Sidebar.test.jsx
@@ -78,4 +78,20 @@ describe('<Sidebar />', () => {
     const expandAllButton = getByTestId('expand-all-button');
     fireEvent.click(expandAllButton);
   });
+
+  it('closes sidebar on unit selection in mobile', async () => {
+    const currentUnitId = Object.keys(sidebarMockStore.models.units)[0];
+    const { getByTestId } = render(<Sidebar currentUnitId={currentUnitId} />, { store });
+
+    // Sidebar is already open according to mock data in sidebarMockStore
+    const { courseView: { isMobileSidebarOpen: isMobileSidebarOpenInitial } } = store.getState();
+    expect(isMobileSidebarOpenInitial).toBeTruthy();
+
+    const unitButton = getByTestId('unit-button-block-v1:edX+DemoX+Demo_Course+type@vertical+block@vertical_0270f6de40fc');
+    fireEvent.click(unitButton);
+
+    // It should be closed after clicking a unit
+    const { courseView: { isMobileSidebarOpen: isMobileSidebarOpenFinal } } = store.getState();
+    expect(isMobileSidebarOpenFinal).toBeFalsy();
+  });
 });


### PR DESCRIPTION
# Overview

Close sidebar on unit selection in mobile.

## Checklist

⚠️ **Please make sure to fill this checklist before asking for reviews.**

- [x] Code is correctly formatted and linted
- [x] Unit tests are updated and are passing
- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary):
      i.e. `feat(CUR-###): Feature title`
- [x] PR Title aligns to Semantic-Release [supported prefixes](https://www.conventionalcommits.org/en/v1.0.0/#examples) (NOTE: prefixes are case sensitive, keep lower-case):

```diff
 feat() - Feature (0.X.0)
 fix() - Patch (0.0.X)
 docs() - Patch (0.0.X), will only scope to README changes
 refactor() - Patch (0.0.X)
 revert() - Patch (0.0.X)
 style() - Patch (0.0.X)
```

- [x] Check for unused files
- [x] Check work before asking for reviewers
- [x] Fix any linting errors
- [x] SECURITY: No secrets where commited to the repo
- [x] COMPLIANCE: Commited code is not propietary and adheres to Open Source licensing
