### PR TITLE
feat(DEX-4132): Avoid error while course is loading

### DIFF
--- a/src/components/SimpleLoader/SimpleLoader.jsx
+++ b/src/components/SimpleLoader/SimpleLoader.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Spinner } from '@edx/paragon';
+
+const SimpleLoader = () => (
+  <div className="simple-loader text-center m-4">
+    <span className="simple-loader-container">
+      <Spinner animation="border" className="spinner-border text-primary" screenReaderText="loading" />
+    </span>
+  </div>
+);
+
+export default SimpleLoader;

--- a/src/components/SimpleLoader/SimpleLoader.jsx
+++ b/src/components/SimpleLoader/SimpleLoader.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Spinner } from '@edx/paragon';
 
 const SimpleLoader = () => (
-  <div className="simple-loader text-center m-4">
+  <div className="simple-loader text-center m-4" data-testid="simple-loader">
     <span className="simple-loader-container">
       <Spinner animation="border" className="spinner-border text-primary" screenReaderText="loading" />
     </span>

--- a/src/components/SimpleLoader/SimpleLoader.scss
+++ b/src/components/SimpleLoader/SimpleLoader.scss
@@ -1,0 +1,13 @@
+.simple-loader {
+  .simple-loader-container {
+    background-color: $white;
+    padding: 16px;
+    border-radius: 32px;
+    width: 64px;
+    height: 64px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    @include pgn-box-shadow(2, "down");
+  }
+}

--- a/src/features/course-player/CoursePlayer.jsx
+++ b/src/features/course-player/CoursePlayer.jsx
@@ -27,6 +27,7 @@ import {
   checkSequenceToSequenceUnitRedirect,
   checkSequenceUnitMarkerToSequenceUnitRedirect,
 } from './data/utils';
+import SimpleLoader from '../../components/SimpleLoader/SimpleLoader';
 
 ensureConfig([
   'DISABLE_APP_HEADER',
@@ -208,24 +209,31 @@ const CoursePlayer = (props) => {
     }
   };
 
+  const isReadyToShow = () => {
+    // Avoid crashes with invalid course or sequence states
+    const isInvalidState = (courseId !== (routeCourseId || null) || sequenceId !== (routeSequenceId || null));
+    // Only consider we are ready to render SequenceContainer once we get all required route params
+    const isReady = routeCourseId != null && routeSequenceId != null && routeUnitId != null;
+    return !isInvalidState && isReady;
+  };
+
   return (
     <div className={classNames('course-player-main-content', { 'disable-app-header': disableAppHeader })}>
       <Helmet>
         <title>{`${course?.title || 'Course'} | ${getConfig().SITE_NAME}`}</title>
       </Helmet>
-      {/* Avoud crashes with invalid course or sequence states */}
-      {!(courseId !== (routeCourseId || null) || sequenceId !== (routeSequenceId || null)) && (
-      <div className="course-player-sequence-container">
-        <SequenceContainer
-          courseId={routeCourseId}
-          sequenceId={routeSequenceId}
-          unitId={routeUnitId}
-          unitNavigationHandler={handleUnitNavigationClick}
-          nextSequenceHandler={handleNextSequenceClick}
-          previousSequenceHandler={handlePreviousSequenceClick}
-        />
-      </div>
-      )}
+      {isReadyToShow() ? (
+        <div className="course-player-sequence-container">
+          <SequenceContainer
+            courseId={routeCourseId}
+            sequenceId={routeSequenceId}
+            unitId={routeUnitId}
+            unitNavigationHandler={handleUnitNavigationClick}
+            nextSequenceHandler={handleNextSequenceClick}
+            previousSequenceHandler={handlePreviousSequenceClick}
+          />
+        </div>
+      ) : <SimpleLoader />}
     </div>
   );
 };

--- a/src/features/course-player/CoursePlayer.test.jsx
+++ b/src/features/course-player/CoursePlayer.test.jsx
@@ -8,6 +8,7 @@ import CoursePlayer from './CoursePlayer';
 
 describe('CoursePlayer', () => {
   let mockData;
+  let store;
   const courseMetadata = Factory.build('courseMetadata');
   const unitBlocks = Array.from({ length: 3 }).map(() => Factory.build(
     'block',
@@ -16,7 +17,7 @@ describe('CoursePlayer', () => {
   ));
 
   beforeAll(async () => {
-    const store = await initializeTestStore({ courseMetadata, unitBlocks });
+    store = await initializeTestStore({ courseMetadata, unitBlocks });
     const { courseware } = store.getState();
     mockData = {
       match: {
@@ -38,5 +39,67 @@ describe('CoursePlayer', () => {
     await waitFor(() => expect(screen.queryByText('Loading learning sequence...')).toBeInTheDocument());
     loadUnit();
     await waitFor(() => expect(screen.queryByText('Loading learning sequence...')).not.toBeInTheDocument());
+  });
+
+  describe('when the content is not ready to show', () => {
+    it('shows loading spinner when sequenceId and unitId are not set in the url', async () => {
+      const { courseware } = store.getState();
+      const incompleteMockData = {
+        match: {
+          params: {
+            courseId: courseware.courseId,
+            sequenceId: null,
+            unitId: null,
+          },
+        },
+      };
+      render(<CoursePlayer {...incompleteMockData} />);
+      await waitFor(() => expect(screen.queryByTestId('simple-loader')).toBeInTheDocument());
+    });
+
+    it('shows loading spinner when courseId is not set in the url', async () => {
+      const { courseware } = store.getState();
+      const incompleteMockData = {
+        match: {
+          params: {
+            courseId: null,
+            sequenceId: courseware.sequenceId,
+            unitId: unitBlocks[0].id,
+          },
+        },
+      };
+      render(<CoursePlayer {...incompleteMockData} />);
+      await waitFor(() => expect(screen.queryByTestId('simple-loader')).toBeInTheDocument());
+    });
+
+    it('shows loading spinner when sequenceId is not set in the url', async () => {
+      const { courseware } = store.getState();
+      const incompleteMockData = {
+        match: {
+          params: {
+            courseId: courseware.courseId,
+            sequenceId: null,
+            unitId: unitBlocks[0].id,
+          },
+        },
+      };
+      render(<CoursePlayer {...incompleteMockData} />);
+      await waitFor(() => expect(screen.queryByTestId('simple-loader')).toBeInTheDocument());
+    });
+
+    it('shows loading spinner when unitId is not set in the url', async () => {
+      const { courseware } = store.getState();
+      const incompleteMockData = {
+        match: {
+          params: {
+            courseId: courseware.courseId,
+            sequenceId: courseware.sequenceId,
+            unitId: null,
+          },
+        },
+      };
+      render(<CoursePlayer {...incompleteMockData} />);
+      await waitFor(() => expect(screen.queryByTestId('simple-loader')).toBeInTheDocument());
+    });
   });
 });

--- a/src/features/sidebar/Sidebar.jsx
+++ b/src/features/sidebar/Sidebar.jsx
@@ -9,6 +9,7 @@ import collapsibleMenuStateSelector from './data/selectors';
 import CarrotIconTop from '../../assets/CarrotIconTop';
 import { toggleDesktopSidebar } from '../course-view/data/slice';
 import CarrotIconRight from '../../assets/CarrotIconRight';
+import SimpleLoader from '../../components/SimpleLoader/SimpleLoader';
 
 const Sidebar = ({ currentUnitId, sequenceId, isSidebarExtended }) => {
   const dispatch = useDispatch();
@@ -44,6 +45,7 @@ const Sidebar = ({ currentUnitId, sequenceId, isSidebarExtended }) => {
       </div>
       <button type="button" className="sidebar-content" onClick={handleSidebarContentClick}>
         <div className="white-background">
+          {!sectionSequenceUnits?.length && <SimpleLoader />}
           {sectionSequenceUnits?.map(section => (
             <Section
               key={section.id}

--- a/src/features/sidebar/Sidebar.test.jsx
+++ b/src/features/sidebar/Sidebar.test.jsx
@@ -94,4 +94,39 @@ describe('<Sidebar />', () => {
     const { courseView: { isMobileSidebarOpen: isMobileSidebarOpenFinal } } = store.getState();
     expect(isMobileSidebarOpenFinal).toBeFalsy();
   });
+
+  it('shows loading spinner while the sectionSequenceUnits store variable is empty', async () => {
+    const currentUnitId = Object.keys(sidebarMockStore.models.units)[0];
+
+    const emptyStore = configureStore({
+      reducer: {
+        models: modelsReducer,
+        courseware: coursewareReducer,
+        courseView: courseViewReducer,
+        sidebar: sidebarReducer,
+      },
+      preloadedState: {
+        ...sidebarMockStore,
+        models: {
+          ...sidebarMockStore.models,
+          sections: {},
+          sequences: {},
+          units: {},
+        },
+      },
+    });
+
+    const { queryByTestId } = render(<Sidebar currentUnitId={currentUnitId} />, { store: emptyStore });
+
+    const loader = queryByTestId('simple-loader');
+    expect(loader).toBeInTheDocument();
+  });
+
+  it('doesnt show loading spinner when sectionSequenceUnits is not empty', async () => {
+    const currentUnitId = Object.keys(sidebarMockStore.models.units)[0];
+    const { queryByTestId } = render(<Sidebar currentUnitId={currentUnitId} />, { store });
+
+    const loader = queryByTestId('simple-loader');
+    expect(loader).not.toBeInTheDocument();
+  });
 });

--- a/src/index.scss
+++ b/src/index.scss
@@ -9,6 +9,7 @@
 @import "features/course-player/sequence-container/SequenceContainer.scss";
 @import "features/header/Header.scss";
 @import "features/footer/Footer.scss";
+@import "components/SimpleLoader/SimpleLoader.scss";
 
 #root {
   display: flex;


### PR DESCRIPTION
# Overview

When the app was loaded with an incomplete cuirse/section/unit url (only course, or partial), it showed a message error to the student just before redirecting to the correct url and start loading.

Added logic to avoid that and also added loading spinners.

## Checklist

⚠️ **Please make sure to fill this checklist before asking for reviews.**

- [x] Code is correctly formatted and linted
- [x] Unit tests are updated and are passing
- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary):
      i.e. `feat(CUR-###): Feature title`
- [ x PR Title aligns to Semantic-Release [supported prefixes](https://www.conventionalcommits.org/en/v1.0.0/#examples) (NOTE: prefixes are case sensitive, keep lower-case):

```diff
 feat() - Feature (0.X.0)
 fix() - Patch (0.0.X)
 docs() - Patch (0.0.X), will only scope to README changes
 refactor() - Patch (0.0.X)
 revert() - Patch (0.0.X)
 style() - Patch (0.0.X)
```

- [x] Check for unused files
- [x] Check work before asking for reviewers
- [x] Fix any linting errors
- [x] SECURITY: No secrets where commited to the repo
- [x] COMPLIANCE: Commited code is not propietary and adheres to Open Source licensing
