### PR TITLE
feat(DEX-4209): focus on current unit when user expands all content

### DIFF
--- a/src/features/course-view/CourseView.scss
+++ b/src/features/course-view/CourseView.scss
@@ -342,11 +342,9 @@ button.sidebar-item-container {
 
 
 .sidebar-item-collapsable {
-  max-height: 1500px;
-  transition: max-height 0.6s ease;
+  display: block;
 }
 
 .sidebar-item-collapsable.collapsed {
-  max-height: 0;
-  overflow: hidden;
+  display: none;
 }

--- a/src/features/sidebar/Sidebar.jsx
+++ b/src/features/sidebar/Sidebar.jsx
@@ -47,8 +47,8 @@ const Sidebar = ({ currentUnitId, sequenceId, isSidebarExtended }) => {
   return (
     <div className="sidebar-container">
       <div className="sidebar-header">
-        <button data-testid="collapse-all-button" type="button" onClick={handleExpandAll}><CarrotIconDown />Expand All</button>
-        <button data-testid="expand-all-button" type="button" onClick={handleCollapseAll}><CarrotIconTop />Collapse All</button>
+        <button data-testid="expand-all-button" type="button" onClick={handleExpandAll}><CarrotIconDown />Expand All</button>
+        <button data-testid="collapse-all-button" type="button" onClick={handleCollapseAll}><CarrotIconTop />Collapse All</button>
         {isSidebarExtended ? <CarrotIconLeft onClick={toggle} /> : <CarrotIconRight onClick={toggle} />}
       </div>
       <button type="button" className="sidebar-content" onClick={handleSidebarContentClick}>

--- a/src/features/sidebar/Sidebar.jsx
+++ b/src/features/sidebar/Sidebar.jsx
@@ -25,9 +25,17 @@ const Sidebar = ({ currentUnitId, sequenceId, isSidebarExtended }) => {
     dispatch(toggleOpenCollapseSidebarItem({ id }));
   };
 
+  const scrollToCurrentUnit = () => {
+    const currentUnit = document.querySelector('.sidebar-item-header.current');
+    setTimeout(() => currentUnit.scrollIntoView({ behavior: 'smooth', inline: 'center', block: 'center' }), 0);
+  };
+
   const handleCollapseAll = () => dispatch(collapseAllSidebarItems());
 
-  const handleExpandAll = () => dispatch(expandAllSidebarItems());
+  const handleExpandAll = () => {
+    dispatch(expandAllSidebarItems());
+    scrollToCurrentUnit();
+  };
 
   const handleSidebarContentClick = () => {
     if (isSidebarExtended) {

--- a/src/features/sidebar/Sidebar.test.jsx
+++ b/src/features/sidebar/Sidebar.test.jsx
@@ -72,6 +72,8 @@ describe('<Sidebar />', () => {
   });
 
   it('expand all sidebar items', () => {
+    const scrollIntoViewMock = jest.fn();
+    HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;
     const currentUnitId = Object.keys(sidebarMockStore.models.units)[0];
     const { getByTestId } = render(<Sidebar currentUnitId={currentUnitId} />, { store });
 


### PR DESCRIPTION
# Overview
When user click expand all button i scroll to current unit view so user don't get lost.


## Checklist

⚠️ **Please make sure to fill this checklist before asking for reviews.**

- [x] Code is correctly formatted and linted
- [x] Unit tests are updated and are passing
- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary):
      i.e. `feat(CUR-###): Feature title`
- [x] PR Title aligns to Semantic-Release [supported prefixes](https://www.conventionalcommits.org/en/v1.0.0/#examples) (NOTE: prefixes are case sensitive, keep lower-case):

```diff
 feat() - Feature (0.X.0)
 fix() - Patch (0.0.X)
 docs() - Patch (0.0.X), will only scope to README changes
 refactor() - Patch (0.0.X)
 revert() - Patch (0.0.X)
 style() - Patch (0.0.X)
```

- [x] Check for unused files
- [x] Check work before asking for reviewers
- [x] Fix any linting errors
- [x] SECURITY: No secrets where commited to the repo
- [x] COMPLIANCE: Commited code is not propietary and adheres to Open Source licensing
