### PR TITLE
refactor(DEX-4167): sidebar icons align, sidebar and content padding,…

### DIFF
--- a/src/features/course-player/CoursePlayer.scss
+++ b/src/features/course-player/CoursePlayer.scss
@@ -1,7 +1,8 @@
 .course-player-main-content {
   background-color: $primary-300;
-  padding: 1rem 2rem 3.25rem 2rem;
   min-height: calc(100vh - $desktop-footer-height - $desktop-header-height);
+  padding: 1rem 2rem 3.25rem 4rem;
+
   .course-player-sequence-container {
     padding: 0.5rem 1rem;
     border-radius: 0.5rem;
@@ -14,8 +15,8 @@
   }
 
   @media (max-width: map-get($grid-breakpoints, "xl")) {
-    padding: 0rem;
-    
+    padding: 0px !important;
+
     .course-player-sequence-container {
       padding: 0rem;
       border-radius: 0rem;
@@ -27,10 +28,12 @@
     }
   }
 
+
+
   @media (max-width: map-get($grid-breakpoints, "lg")) {
     // Makes sure footer is always at least at the bottom of the screen:
     min-height: calc(100vh - $mobile-footer-height - $mobile-header-height);
   }
 
-  
+
 }

--- a/src/features/course-view/CourseView.scss
+++ b/src/features/course-view/CourseView.scss
@@ -1,7 +1,7 @@
 .cv-course-sidebar {
   position: fixed;
   top: 0;
-  left: -362px;
+  left: -355px;
   height: 100vh;
   width: $extended-sidebar-width;
   padding-top: $desktop-header-height;
@@ -64,7 +64,6 @@
 .sidebar-header {
   background-color: $gray-100;
   padding: 16px;
-  padding-right: 24px;
   display: flex;
   gap: 8px;
   border-top-right-radius: 32px;
@@ -102,7 +101,13 @@
     align-items: center;
 
     &:last-of-type {
-      margin-right: 40px;
+      background: none;
+      border: 0;
+      padding: 0;
+      flex-grow: 0;
+      gap: 0px;
+      padding: 12px 12px 12px 12px;
+      margin-left: 30px;
 
       @media (max-width: map-get($grid-breakpoints, "xl")) {
         margin-right: 0px;
@@ -131,6 +136,7 @@
 
 
 .cv-course-content {
+  transition: padding-left 0.5s ease-in-out;
   padding-left: $minimized-sidebar-width;
 
   @media (max-width: map-get($grid-breakpoints, "xl")) {
@@ -139,7 +145,7 @@
 }
 
 .cv-course-content-sidebar-extended {
-  padding-left: $extended-sidebar-width;
+  padding-left: calc($extended-sidebar-width - 4rem);
 
   @media (max-width: map-get($grid-breakpoints, "xl")) {
     padding-left: 0px;
@@ -286,11 +292,13 @@ button.sidebar-item-container {
 .sidebar-item-header.sequence svg:last-of-type {
   height: 16px;
   width: 16px;
+  margin-right: 3.6px;
 }
 
 .sidebar-item-header.unit svg:last-of-type {
   height: 16px;
   width: 16px;
+  margin-right: 3.6px;
 }
 
 .sidebar-item-header.active.completed svg {
@@ -316,6 +324,8 @@ button.sidebar-item-container {
 .sidebar-item-header.in-progress svg {
   color: #858585;
 }
+
+
 
 
 .sidebar-item-header.current {

--- a/src/features/sidebar/Sidebar.jsx
+++ b/src/features/sidebar/Sidebar.jsx
@@ -41,7 +41,7 @@ const Sidebar = ({ currentUnitId, sequenceId, isSidebarExtended }) => {
       <div className="sidebar-header">
         <button data-testid="collapse-all-button" type="button" onClick={handleExpandAll}><CarrotIconDown />Expand All</button>
         <button data-testid="expand-all-button" type="button" onClick={handleCollapseAll}><CarrotIconTop />Collapse All</button>
-        {isSidebarExtended ? <CarrotIconLeft onClick={toggle} /> : <CarrotIconRight onClick={toggle} />}
+        <button type="button" onClick={toggle}>{isSidebarExtended ? <CarrotIconLeft /> : <CarrotIconRight />}</button>
       </div>
       <button type="button" className="sidebar-content" onClick={handleSidebarContentClick}>
         <div className="white-background">

--- a/src/features/sidebar/Sidebar.jsx
+++ b/src/features/sidebar/Sidebar.jsx
@@ -47,8 +47,8 @@ const Sidebar = ({ currentUnitId, sequenceId, isSidebarExtended }) => {
   return (
     <div className="sidebar-container">
       <div className="sidebar-header">
-        <button data-testid="collapse-all-button" type="button" onClick={handleExpandAll}><CarrotIconDown />Expand All</button>
-        <button data-testid="expand-all-button" type="button" onClick={handleCollapseAll}><CarrotIconTop />Collapse All</button>
+        <button data-testid="expand-all-button" type="button" onClick={handleExpandAll}><CarrotIconDown />Expand All</button>
+        <button data-testid="collapse-all-button" type="button" onClick={handleCollapseAll}><CarrotIconTop />Collapse All</button>
         <button type="button" onClick={toggle}>{isSidebarExtended ? <CarrotIconLeft /> : <CarrotIconRight />}</button>
       </div>
       <button type="button" className="sidebar-content" onClick={handleSidebarContentClick}>


### PR DESCRIPTION


# Overview

Sidebar icons were aligned 
Content have padding when sidebar is hidden. 
The sidebar hide button is more easy to click.
Icons when sidebar is hidden are aligned and have more padding.

## Checklist

⚠️ **Please make sure to fill this checklist before asking for reviews.**

- [x] Code is correctly formatted and linted
- [x] Unit tests are updated and are passing
- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary):
      i.e. `feat(CUR-###): Feature title`
- [x] PR Title aligns to Semantic-Release [supported prefixes](https://www.conventionalcommits.org/en/v1.0.0/#examples) (NOTE: prefixes are case sensitive, keep lower-case):

```diff
 feat() - Feature (0.X.0)
 fix() - Patch (0.0.X)
 docs() - Patch (0.0.X), will only scope to README changes
 refactor() - Patch (0.0.X)
 revert() - Patch (0.0.X)
 style() - Patch (0.0.X)
```

- [x] Check for unused files
- [x] Check work before asking for reviewers
- [x] Fix any linting errors
- [x] SECURITY: No secrets where commited to the repo
- [x] COMPLIANCE: Commited code is not propietary and adheres to Open Source licensing
