### PR TITLE
fix(DEX-4215): Make footer closer to the original design

### DIFF
--- a/src/features/footer/Footer.scss
+++ b/src/features/footer/Footer.scss
@@ -2,38 +2,31 @@
   background-color: $info-100;
   font-size: 14px;
   height: $desktop-footer-height;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
 
   @media (max-width: map-get($grid-breakpoints, "lg")) {
-    height: $mobile-footer-height;
-    display: flex;
-    flex-direction: column;
-    justify-content: space-around;
+    height: unset;
+    min-height: $mobile-footer-height;
   }
 
   .footer-section-container {
     display: flex;
-    padding: 8px 40px;
+    padding: 0px 40px;
     justify-content: space-between;
     align-items: center;
     gap: 0px;
 
     img {
-      max-height: 24px;
-      height: 24px;
+      max-height: 32px;
+      height: 32px;
     }
 
     .footer-links-container {
       display: flex;
       column-gap: 12px;
       flex-wrap: wrap;
-    }
-
-    @media (min-width: map-get($grid-breakpoints, "xl")) and (max-width: map-get($grid-breakpoints, "xxl")) {
-      padding: 8px 8px;
-
-      .footer-copy {
-        font-size: 0.8em;
-      }
     }
 
     @media (max-width: map-get($grid-breakpoints, "sm")) {
@@ -43,6 +36,10 @@
 
   .footer-bottom-container {
     padding-top: 0px;
+
+    .footer-copy {
+      flex: 0.8;
+    }
 
     @media (max-width: map-get($grid-breakpoints, "lg")) {
       flex-direction: column;

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -1,10 +1,10 @@
 $shadow-color: #0000001a;
 
 $desktop-header-height: 63.11px;
-$desktop-footer-height: 69.77px;
+$desktop-footer-height: 104px;
 
 $mobile-header-height: 63.11px;
-$mobile-footer-height: 143.09px;
+$mobile-footer-height: 124px;
 
 $extended-sidebar-width: 457px;
 $minimized-sidebar-width: 36px;


### PR DESCRIPTION
# Overview

Address observations on logo and overall footer size.

Changed footer height to match original design. It was made smaller to give more space for the content when the footer was always visible, however now the footer is not always visible so this doesn't matter anymore.

Also did changes to make the layout smarter so it looks good even when text overflows.

## Checklist

⚠️ **Please make sure to fill this checklist before asking for reviews.**

- [x] Code is correctly formatted and linted
- [x] Unit tests are updated and are passing
- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary):
      i.e. `feat(CUR-###): Feature title`
- [x] PR Title aligns to Semantic-Release [supported prefixes](https://www.conventionalcommits.org/en/v1.0.0/#examples) (NOTE: prefixes are case sensitive, keep lower-case):

```diff
 feat() - Feature (0.X.0)
 fix() - Patch (0.0.X)
 docs() - Patch (0.0.X), will only scope to README changes
 refactor() - Patch (0.0.X)
 revert() - Patch (0.0.X)
 style() - Patch (0.0.X)
```

- [x] Check for unused files
- [x] Check work before asking for reviewers
- [x] Fix any linting errors
- [x] SECURITY: No secrets where commited to the repo
- [x] COMPLIANCE: Commited code is not propietary and adheres to Open Source licensing
