### PR TITLE
WIP feat(DEX-4319): Bookmark expands to current unit

### DIFF
--- a/src/components/Section/Section.jsx
+++ b/src/components/Section/Section.jsx
@@ -17,14 +17,26 @@ const Section = ({
   currentUnitId, collapsibleMenuState = {}, id, title, status = 'pending', sequences = [], onOpenCollapse, isActiveSection, currentSequenceId, courseId,
 }) => {
   const hasCurrentUnit = sequences.some(sequence => sequence.units.some(unit => unit.id === currentUnitId));
+
+  const handleOpenCollapse = () => onOpenCollapse(id);
+  const handleOpenCollapseCurrentSequence = () => {
+    onOpenCollapse(id, true);
+    onOpenCollapse(currentSequenceId, true);
+  };
+
   return (
     <div className="sidebar-item-container">
-      <div className={classNames('current-unit-flag', { visible: hasCurrentUnit && !collapsibleMenuState[id] })} />
+      <button
+        type="button"
+        className={classNames('current-unit-flag', { visible: hasCurrentUnit && !collapsibleMenuState[id] })}
+        onClick={handleOpenCollapseCurrentSequence}
+        aria-label="Bookmark"
+      />
       <button
         data-testid={`section-button-${id}`}
         type="button"
         className={classNames('sidebar-item-header', { active: isActiveSection, 'has-current-unit': hasCurrentUnit && !collapsibleMenuState[id] }, status, 'section')}
-        onClick={() => onOpenCollapse(id)}
+        onClick={handleOpenCollapse}
       >{collapsibleMenuState[id] ? <CarrotIconDown className="carrot-down" /> : <CarrotIconRight className="carrot" />} <span className="sidebar-item-title">{title}</span> {statusIcons[status]}
       </button>
       <div data-testid={`section-collapsable-${id}`} className={`sidebar-item-collapsable ${!collapsibleMenuState[id] && 'collapsed'}`}>

--- a/src/components/Sequence/Sequence.jsx
+++ b/src/components/Sequence/Sequence.jsx
@@ -15,43 +15,52 @@ const statusIcons = {
 
 const Sequence = ({
   id, title, status = 'pending', units = [], onOpenCollapse, collapsibleMenuState = {}, currentUnitId, isActiveSequence, hasCurrentUnit, sectionId, courseId,
-}) => (
-  <div className="sidebar-item-container">
-    <div className={classNames('current-unit-flag', { visible: hasCurrentUnit && collapsibleMenuState[sectionId] && !collapsibleMenuState[id] })} />
-    <button
-      data-testid={`sequence-button-${id}`}
-      type="button"
-      className={classNames(
-        'sidebar-item-header',
-        {
-          active: isActiveSequence,
-          'has-current-unit': hasCurrentUnit && collapsibleMenuState[sectionId] && !collapsibleMenuState[id],
-        },
-        status,
-        'sequence',
-      )}
-      onClick={() => onOpenCollapse(id, 'sequence')}
-    >
-      {units.length > 0 && (collapsibleMenuState[id] ? <CarrotIconDown className="carrot-down" /> : <CarrotIconRight className="carrot" />)}
-      <span className="sidebar-item-title">{title}</span>
-      {statusIcons[status]}
-    </button>
-    <div data-testid={`sequence-collapsable-${id}`} className={`sidebar-item-collapsable ${!collapsibleMenuState[id] && 'collapsed'}`}>
-      {units.map(unit => (
-        <Unit
-          key={unit.id}
-          courseId={courseId}
-          complete={unit.complete}
-          id={unit.id}
-          sequenceId={id}
-          title={unit.title}
-          isActiveUnit={isActiveSequence}
-          isCurrentUnit={currentUnitId === unit.id}
-        />
-      ))}
+}) => {
+  const handleOpenCollapse = () => onOpenCollapse(id);
+
+  return (
+    <div className="sidebar-item-container">
+      <button
+        type="button"
+        className={classNames('current-unit-flag', { visible: hasCurrentUnit && collapsibleMenuState[sectionId] && !collapsibleMenuState[id] })}
+        onClick={handleOpenCollapse}
+        aria-label="Bookmark"
+      />
+      <button
+        data-testid={`sequence-button-${id}`}
+        type="button"
+        className={classNames(
+          'sidebar-item-header',
+          {
+            active: isActiveSequence,
+            'has-current-unit': hasCurrentUnit && collapsibleMenuState[sectionId] && !collapsibleMenuState[id],
+          },
+          status,
+          'sequence',
+        )}
+        onClick={handleOpenCollapse}
+      >
+        {units.length > 0 && (collapsibleMenuState[id] ? <CarrotIconDown className="carrot-down" /> : <CarrotIconRight className="carrot" />)}
+        <span className="sidebar-item-title">{title}</span>
+        {statusIcons[status]}
+      </button>
+      <div data-testid={`sequence-collapsable-${id}`} className={`sidebar-item-collapsable ${!collapsibleMenuState[id] && 'collapsed'}`}>
+        {units.map(unit => (
+          <Unit
+            key={unit.id}
+            courseId={courseId}
+            complete={unit.complete}
+            id={unit.id}
+            sequenceId={id}
+            title={unit.title}
+            isActiveUnit={isActiveSequence}
+            isCurrentUnit={currentUnitId === unit.id}
+          />
+        ))}
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 Sequence.propTypes = {
   id: PropTypes.string.isRequired,

--- a/src/features/course-view/CourseView.scss
+++ b/src/features/course-view/CourseView.scss
@@ -174,6 +174,7 @@
   & .current-unit-flag {
     height: 48px;
     width: 24px;
+    border: none;
     border-top-right-radius: 100px;
     border-bottom-right-radius: 100px;
     background-color: $primary-500;

--- a/src/features/sidebar/Sidebar.jsx
+++ b/src/features/sidebar/Sidebar.jsx
@@ -5,7 +5,9 @@ import { sectionSequenceUnitsSelector, currentCourseIdSelector } from '../course
 import Section from '../../components/Section/Section';
 import CarrotIconLeft from '../../assets/CarrotIconLeft';
 import CarrotIconDown from '../../assets/CarrotIcon';
-import { collapseAllSidebarItems, expandAllSidebarItems, toggleOpenCollapseSidebarItem } from './data/slice';
+import {
+  collapseAllSidebarItems, expandAllSidebarItems, setOpenCollapseSidebarItem, toggleOpenCollapseSidebarItem,
+} from './data/slice';
 import collapsibleMenuStateSelector from './data/selectors';
 import CarrotIconTop from '../../assets/CarrotIconTop';
 import { toggleDesktopSidebar } from '../course-view/data/slice';
@@ -22,7 +24,12 @@ const Sidebar = ({ currentUnitId, sequenceId, isSidebarExtended }) => {
     dispatch(toggleDesktopSidebar());
   };
 
-  const handleOpenCollapse = (id) => {
+  // isOpen is optional, toggles if not set
+  const handleOpenCollapse = (id, isOpen) => {
+    if (isOpen != null) {
+      dispatch(setOpenCollapseSidebarItem({ id, isOpen }));
+      return;
+    }
     dispatch(toggleOpenCollapseSidebarItem({ id }));
   };
 

--- a/src/features/sidebar/data/slice.js
+++ b/src/features/sidebar/data/slice.js
@@ -15,6 +15,9 @@ const slice = createSlice({
     toggleOpenCollapseSidebarItem: (state, { payload: { id } }) => {
       state.collapsibleMenuState[id] = Boolean(!state.collapsibleMenuState[id]);
     },
+    setOpenCollapseSidebarItem: (state, { payload: { id, isOpen } }) => {
+      state.collapsibleMenuState[id] = Boolean(isOpen);
+    },
     collapseAllSidebarItems: (state => {
       const sidebarItemKeys = Object.keys(state.collapsibleMenuState);
       for (let index = 0; index < sidebarItemKeys.length; index++) {
@@ -35,6 +38,7 @@ const slice = createSlice({
 export const {
   updateCollapsibleMenuState,
   toggleOpenCollapseSidebarItem,
+  setOpenCollapseSidebarItem,
   collapseAllSidebarItems,
   expandAllSidebarItems,
 } = slice.actions;


### PR DESCRIPTION
# Overview

When content is collapsed and user clicks on bookmark, it should expand and bring user to the unit they're in

## Checklist

⚠️ **Please make sure to fill this checklist before asking for reviews.**

- [ ] Code is correctly formatted and linted
- [ ] Unit tests are updated and are passing
- [ ] PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary):
      i.e. `feat(CUR-###): Feature title`
- [ ] PR Title aligns to Semantic-Release [supported prefixes](https://www.conventionalcommits.org/en/v1.0.0/#examples) (NOTE: prefixes are case sensitive, keep lower-case):

```diff
 feat() - Feature (0.X.0)
 fix() - Patch (0.0.X)
 docs() - Patch (0.0.X), will only scope to README changes
 refactor() - Patch (0.0.X)
 revert() - Patch (0.0.X)
 style() - Patch (0.0.X)
```

- [ ] Check for unused files
- [ ] Check work before asking for reviewers
- [ ] Fix any linting errors
- [ ] SECURITY: No secrets where commited to the repo
- [ ] COMPLIANCE: Commited code is not propietary and adheres to Open Source licensing
