### PR TITLE
fix(DEX-4398): Fix a11y issue by refactoring focusable container

### DIFF
--- a/src/features/sidebar/Sidebar.jsx
+++ b/src/features/sidebar/Sidebar.jsx
@@ -24,6 +24,13 @@ const Sidebar = ({ currentUnitId, sequenceId, isSidebarExtended }) => {
     dispatch(toggleDesktopSidebar());
   };
 
+  const handleSidebarContentClick = () => {
+    if (isSidebarExtended) {
+      return;
+    }
+    toggle();
+  };
+
   // isOpen is optional, toggles if not set
   const handleOpenCollapse = (id, isOpen) => {
     if (isOpen != null) {
@@ -31,6 +38,9 @@ const Sidebar = ({ currentUnitId, sequenceId, isSidebarExtended }) => {
       return;
     }
     dispatch(toggleOpenCollapseSidebarItem({ id }));
+
+    // Extend sidebar if collapsed while on desktop
+    handleSidebarContentClick();
   };
 
   const scrollToCurrentUnit = () => {
@@ -45,13 +55,6 @@ const Sidebar = ({ currentUnitId, sequenceId, isSidebarExtended }) => {
   const handleExpandAll = () => {
     dispatch(expandAllSidebarItems());
     scrollToCurrentUnit();
-  };
-
-  const handleSidebarContentClick = () => {
-    if (isSidebarExtended) {
-      return;
-    }
-    toggle();
   };
 
   useEffect(() => {
@@ -106,7 +109,7 @@ const Sidebar = ({ currentUnitId, sequenceId, isSidebarExtended }) => {
         <button className="btn-outline-secondary" tabIndex={isSidebarExtended ? 0 : -1} data-testid="collapse-all-button" type="button" onClick={handleCollapseAll}><CarrotIconTop />Collapse All</button>
         <button type="button" onClick={toggle}>{isSidebarExtended ? <CarrotIconLeft /> : <CarrotIconRight />}</button>
       </div>
-      <div role="button" tabIndex={-1} className="sidebar-content" onClick={handleSidebarContentClick} onKeyDown={() => {}}>
+      <div className="sidebar-content">
         <div className="white-background">
           {!sectionSequenceUnits?.length && <SimpleLoader />}
           {sectionSequenceUnits?.map(section => (
@@ -126,7 +129,6 @@ const Sidebar = ({ currentUnitId, sequenceId, isSidebarExtended }) => {
           ))}
         </div>
       </div>
-      {/* <button type="button" onClick={toggle}>Toggle</button> */}
     </div>
   );
 };


### PR DESCRIPTION
# Overview

Fixes a11y issue described as:
"Ensures interactive controls are not nested as they are not always announced by screen readers or can cause focus problems for assistive technologies"

This was caused because a div container in the sidebar was configured to behave as a button in order to be able to catch any click on the sidebar and make it expand if contracted.

Refactored this in order to do it whenever a interactive child is clicked and made that div just a container.

## Checklist

⚠️ **Please make sure to fill this checklist before asking for reviews.**

- [x] Code is correctly formatted and linted
- [x] Unit tests are updated and are passing
- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary):
      i.e. `feat(CUR-###): Feature title`
- [x] PR Title aligns to Semantic-Release [supported prefixes](https://www.conventionalcommits.org/en/v1.0.0/#examples) (NOTE: prefixes are case sensitive, keep lower-case):

```diff
 feat() - Feature (0.X.0)
 fix() - Patch (0.0.X)
 docs() - Patch (0.0.X), will only scope to README changes
 refactor() - Patch (0.0.X)
 revert() - Patch (0.0.X)
 style() - Patch (0.0.X)
```

- [x] Check for unused files
- [ ] Check work before asking for reviewers
- [x] Fix any linting errors
- [x] SECURITY: No secrets where commited to the repo
- [x] COMPLIANCE: Commited code is not propietary and adheres to Open Source licensing
