### PR TITLE
custom button to remove tabindex use and include aria-label

### DIFF
--- a/src/features/sidebar/Sidebar.jsx
+++ b/src/features/sidebar/Sidebar.jsx
@@ -14,6 +14,21 @@ import { closeDesktopSidebar, toggleDesktopSidebar } from '../course-view/data/s
 import CarrotIconRight from '../../assets/CarrotIconRight';
 import SimpleLoader from '../../components/SimpleLoader/SimpleLoader';
 
+const ConditionalButton = ({
+  isSidebarExtended, onClick, dataTestId, children, ariaLabel,
+}) => (
+  <button
+    className="btn-outline-secondary"
+    data-testid={dataTestId}
+    type="button"
+    onClick={onClick}
+    disabled={!isSidebarExtended}
+    aria-label={ariaLabel}
+  >
+    {children}
+  </button>
+);
+
 const Sidebar = ({ currentUnitId, sequenceId, isSidebarExtended }) => {
   const dispatch = useDispatch();
   const courseId = useSelector(currentCourseIdSelector);
@@ -105,9 +120,25 @@ const Sidebar = ({ currentUnitId, sequenceId, isSidebarExtended }) => {
   return (
     <div className="sidebar-container" role="menu">
       <div className="sidebar-header">
-        <button className="btn-outline-secondary" tabIndex={isSidebarExtended ? 0 : -1} data-testid="expand-all-button" type="button" onClick={handleExpandAll}><CarrotIconDown />Expand All</button>
-        <button className="btn-outline-secondary" tabIndex={isSidebarExtended ? 0 : -1} data-testid="collapse-all-button" type="button" onClick={handleCollapseAll}><CarrotIconTop />Collapse All</button>
-        <button type="button" onClick={toggle}>{isSidebarExtended ? <CarrotIconLeft /> : <CarrotIconRight />}</button>
+        <ConditionalButton
+          isSidebarExtended={isSidebarExtended}
+          onClick={handleExpandAll}
+          dataTestId="expand-all-button"
+          ariaLabel="Expand All"
+        >
+          <CarrotIconDown /> Expand All
+        </ConditionalButton>
+        <ConditionalButton
+          isSidebarExtended={isSidebarExtended}
+          onClick={handleCollapseAll}
+          dataTestId="collapse-all-button"
+          ariaLabel="Collapse All"
+        >
+          <CarrotIconTop /> Collapse All
+        </ConditionalButton>
+        <button type="button" onClick={toggle} aria-label="Toggle Sidebar">
+          {isSidebarExtended ? <CarrotIconLeft /> : <CarrotIconRight />}
+        </button>
       </div>
       <div className="sidebar-content">
         <div className="white-background">
@@ -131,6 +162,14 @@ const Sidebar = ({ currentUnitId, sequenceId, isSidebarExtended }) => {
       </div>
     </div>
   );
+};
+
+ConditionalButton.propTypes = {
+  isSidebarExtended: PropTypes.bool.isRequired,
+  onClick: PropTypes.func.isRequired,
+  dataTestId: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
+  ariaLabel: PropTypes.string.isRequired,
 };
 
 Sidebar.propTypes = {


### PR DESCRIPTION
# Overview

Change to remove the use of tabIndex for these buttons. Change also adds aria-labels

## Checklist

⚠️ **Please make sure to fill this checklist before asking for reviews.**

- [x] Code is correctly formatted and linted
- [x] Unit tests are updated and are passing
- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary):
      i.e. `feat(CUR-###): Feature title`
- [x] PR Title aligns to Semantic-Release [supported prefixes](https://www.conventionalcommits.org/en/v1.0.0/#examples) (NOTE: prefixes are case sensitive, keep lower-case):

```diff
 feat() - Feature (0.X.0)
 fix(x) - Patch (0.0.X)
 docs() - Patch (0.0.X), will only scope to README changes
 refactor() - Patch (0.0.X)
 revert() - Patch (0.0.X)
 style() - Patch (0.0.X)
```

- [x] Check for unused files
- [x] Check work before asking for reviewers
- [x] Fix any linting errors
- [x] SECURITY: No secrets where commited to the repo
- [x] COMPLIANCE: Commited code is not propietary and adheres to Open Source licensing
