### PR TITLE
fix(LER-3680): Fix desktop header disabled media query

### DIFF
--- a/src/features/layout/Layout.jsx
+++ b/src/features/layout/Layout.jsx
@@ -17,7 +17,7 @@ ensureConfig([
 const Layout = ({ children }) => {
   const disableDesktopHeader = getConfig().DISABLE_DESKTOP_HEADER === true;
   const disableAppFooter = getConfig().DISABLE_APP_FOOTER === true;
-  const isMobileDevice = useMediaQuery({ query: '(max-width: 1260px)' });
+  const isMobileDevice = useMediaQuery({ query: '(max-width: 1200px)' });
   const layoutHasSidebar = useSelector(layoutHasSidebarSelector);
   const isSidebarExtended = useSelector(isDesktopSidebarExtendedSelector);
 


### PR DESCRIPTION
# Overview

This fix ensures the desktop header is never displayed when disabled. Prior to this fix the desktop header would display on viewport widths 1200-1260px.

## Checklist

- [x] Code is correctly formatted and linted
- [x] Unit tests are updated and are passing
- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary):
      i.e. `feat(CUR-###): Feature title`
- [x] PR Title aligns to Semantic-Release [supported prefixes](https://www.conventionalcommits.org/en/v1.0.0/#examples) (NOTE: prefixes are case sensitive, keep lower-case):

```diff
 feat() - Feature (0.X.0)
 fix() - Patch (0.0.X)
 docs() - Patch (0.0.X), will only scope to README changes
 refactor() - Patch (0.0.X)
 revert() - Patch (0.0.X)
 style() - Patch (0.0.X)
```

- [x] Check for unused files
- [x] Check work before asking for reviewers
- [x] Fix any linting errors
- [x] SECURITY: No secrets where committed to the repo
- [x] COMPLIANCE: Committed code is not proprietary and adheres to Open Source licensing
