### PR TITLE
feat: Update pendo IIFE handling to evaluate configured IIFE

### DIFF
--- a/src/features/pendo/Pendo.jsx
+++ b/src/features/pendo/Pendo.jsx
@@ -28,7 +28,8 @@ function pendoHelperUser(pendoKey) {
 // Use this function for a custom visitor ID
 async function pendoHelperCustom(pendoKey) {
   // eslint-disable-next-line prefer-const
-  const { username } = getAuthenticatedUser();
+  const authenticatedUser = getAuthenticatedUser();
+  const username = authenticatedUser?.username ?? null;
 
   // eslint-disable-next-line no-shadow
   async function customVisitorIife(lmsUrl, username) {

--- a/src/features/pendo/Pendo.jsx
+++ b/src/features/pendo/Pendo.jsx
@@ -26,14 +26,19 @@ function pendoHelperUser(pendoKey) {
 }
 
 // Use this function for a custom visitor ID
-function pendoHelperCustom(pendoKey) {
+async function pendoHelperCustom(pendoKey) {
   // eslint-disable-next-line prefer-const
-  let visitor = null;
+  const { username } = getAuthenticatedUser();
 
-  // Iife should retreive custom visitor ID and assign to visitor
-  // eslint-disable-next-line no-unused-expressions
-  function customVisitorIife() { getConfig().PENDO_VISITOR_IIFE; }
-  customVisitorIife();
+  // eslint-disable-next-line no-shadow
+  async function customVisitorIife(lmsUrl, username) {
+    if (getConfig().PENDO_VISITOR_IIFE) {
+      // eslint-disable-next-line no-new-func
+      return new Function('lmsUrl', 'username', `return ${getConfig().PENDO_VISITOR_IIFE};`)(lmsUrl, username);
+    }
+    return null;
+  }
+  const visitor = await customVisitorIife(getConfig().LMS_BASE_URL, username);
 
   if (localStorage.getItem(pendoKey === null)) {
     localStorage.setItem(pendoKey, visitor);


### PR DESCRIPTION
The pendo feature now evaluates the IIFE passed in via the MFE configuration, and passes it two arguments, first is the base URL of the lms in `lmsUrl`, and the second is the username in `username`. Note that no error handling is provided for the IIFE, any exceptions within the IIFE will be passed up to the browser. This assists in debugging issues with the IIFE but risks causing errors for end users in the MFE if the IIFE does not catch exceptions.

We use the `Function()` constructor here as it's safer than `eval()`, but does not pass scope into the function so we must pass any needed data as arguments. Currently passing the LMS base URL as well as the username to assist in fetching user data.

The IIFE should fetch whatever data necessary and return the dictionary that will be set into local storage with the key specified by the MFE config's `PENDO_VISITOR_KEY`. An example IIFE that can be set in the MFE config entry `PENDO_VISITOR_IIFE` which fetches from the LMS user api:
```js
"(async function (lmsUrl, username) {\
    let resp = await fetch(`${lmsUrl}/api/user/v1/accounts/${username}`,    { method: \"GET\", credentials: \"include\" });\
    let json = await resp.json();\
    return JSON.stringify({USERID: json[\"email\"]})\
  })(lmsUrl, username).catch(() => { return null; })"
```

# Overview

1. Edit the Site Configuration on the LMS setting the following values under `MFE_CONFIG`:
  - `ENABLE_PENDO: true,`
  - `CUSTOM_PENDO: true,`
  - `PENDO_VISITOR_KEY: "currentPerson",`
  - Set `PENDO_VISITOR_IIFE` from the IIFE snippet above
2. Load a course through the MFE and check that the `currentPerson` key in the browser's local storage is set with a dictionary containing the user's email address 
## Checklist

⚠️ **Please make sure to fill this checklist before asking for reviews.**

- [x] Code is correctly formatted and linted
- [x] Unit tests are updated and are passing
- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary):
      i.e. `feat(CUR-###): Feature title`
- [x] PR Title aligns to Semantic-Release [supported prefixes](https://www.conventionalcommits.org/en/v1.0.0/#examples) (NOTE: prefixes are case sensitive, keep lower-case):

```diff
 feat() - Feature (0.X.0)
 fix() - Patch (0.0.X)
 docs() - Patch (0.0.X), will only scope to README changes
 refactor() - Patch (0.0.X)
 revert() - Patch (0.0.X)
 style() - Patch (0.0.X)
```

- [x] Check for unused files
- [x] Check work before asking for reviewers
- [x] Fix any linting errors
- [x] SECURITY: No secrets where commited to the repo
- [x] COMPLIANCE: Commited code is not propietary and adheres to Open Source licensing
