### PR TITLE
fix: Reset logo height in header (quince)

### DIFF
--- a/src/features/header/Header.scss
+++ b/src/features/header/Header.scss
@@ -24,7 +24,7 @@
 
   .logo {
     max-height: 32px;
-    height: 24px;
+    height: 32px;
     width: auto;
 
     @media (max-width: map-get($grid-breakpoints, "xl")) {


### PR DESCRIPTION
# Overview

On https://github.com/wgu-opensource/openedx-mfe-learning/pull/83, the size of the logo in the header was changed, but this should have been included in the branding styles for the specific project, since this MFE is shared between multiple projects.

This changes the CSS rule for the header logo height back to 32px, and project specific customizations will be made to the associated branding repo.

## Checklist

⚠️ **Please make sure to fill this checklist before asking for reviews.**

- [x] Code is correctly formatted and linted
- [x] Unit tests are updated and are passing
- [x] PR title follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary):
      i.e. `feat(CUR-###): Feature title`
- [x] PR Title aligns to Semantic-Release [supported prefixes](https://www.conventionalcommits.org/en/v1.0.0/#examples) (NOTE: prefixes are case sensitive, keep lower-case):

```diff
 feat() - Feature (0.X.0)
 fix() - Patch (0.0.X)
 docs() - Patch (0.0.X), will only scope to README changes
 refactor() - Patch (0.0.X)
 revert() - Patch (0.0.X)
 style() - Patch (0.0.X)
```

- [x] Check for unused files
- [x] Check work before asking for reviewers
- [x] Fix any linting errors
- [x] SECURITY: No secrets where commited to the repo
- [x] COMPLIANCE: Commited code is not propietary and adheres to Open Source licensing
